### PR TITLE
Add support for EL7

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: update root trust anchor
+  command: "{{ update_root_trust_anchor }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+  - name: EL
+    versions:
+    - 7
   galaxy_tags: 
    - mesos
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,9 @@
+---
+- name: Fail if the OS is not supported
+  fail:
+    msg="This role is not supported on {{ansible_distribution}}"
+  when: "ansible_distribution != 'Ubuntu' and ansible_os_family != 'RedHat'"
+
 - name: create log directory  
   file:
     path: "{{ mesos_log_dir }}"
@@ -6,6 +12,12 @@
   tags:
     - mesos-master
     - mesos-slave
+
+- name: Include distribution-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "vars/{{ ansible_distribution|lower }}.yml"
+    - "vars/{{ ansible_os_family|lower }}.yml"
 
 - include: master.yml
   when: mesos_install_mode == "master"

--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -2,14 +2,15 @@
 # Tasks for Slave nodes
 
 - name: Ensure local certs directory exists
-  file: state=directory path=/usr/local/share/ca-certificates
+  file: state=directory path={{ trust_anchor_root_dir }}
 
 - name: Install rootCA certificate
-  copy: src=rootCA.crt dest=/usr/local/share/ca-certificates/rootCA.crt
+  copy: src=rootCA.crt dest={{ trust_anchor_root_dir }}/rootCA.crt
+  notify:
+    - update root trust anchor
 
-- name: Update cert index
-  shell: /usr/sbin/update-ca-certificates
-
+# Force handler flush so that the rootCA is immediately taken into account
+- meta: flush_handlers
 
 - name: create working dir
   file:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,4 @@
+---
+# Paths and variables for EL7
+trust_anchor_root_dir: /etc/pki/ca-trust/source/anchors
+update_root_trust_anchor: update-ca-trust

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,0 +1,4 @@
+---
+# Paths and variables for Ubuntu
+trust_anchor_root_dir: /usr/local/share/ca-certificates
+update_root_trust_anchor: update-ca-certificates


### PR DESCRIPTION
The required modifications are minimal and account only for the different way
of handling the root trust anchor on the host OS between Ubuntu and EL.
Anything else has not been modified and works as-is.
